### PR TITLE
updated foxml and premis xsl 

### DIFF
--- a/xml/foxml_to_premis.xsl
+++ b/xml/foxml_to_premis.xsl
@@ -1,81 +1,110 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns:php="http://php.net/xsl"
-  xmlns:foxml="info:fedora/fedora-system:def/foxml#" xmlns:audit="info:fedora/fedora-system:def/audit#"
-  xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:fedora-model="info:fedora/fedora-system:def/model#"
-  xmlns:islandora="http://islandora.ca/ontology/relsext#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-  exclude-result-prefixes="php fedora fedora-model foxml audit islandora php rdf">
-
-<xsl:output method="xml" encoding="utf-8" indent="yes"/>
-
-<!-- Define a global parameter containing the Islandora object's PID. -->
-<xsl:param name = "pid" select="foxml:digitalObject/@PID" />
-
-<!-- Global parameters exported from out solution pack. -->
-<xsl:param name="premis_agent_name_organization" />
-<xsl:param name="premis_agent_identifier_organization" />
-<xsl:param name="premis_agent_identifier_type" />
-<xsl:param name="premis_agent_type_organization" />
-
-<xsl:preserve-space elements="*" />
-
-<xsl:template match="foxml:digitalObject">
-    <premis xmlns="info:lc/xmlns/premis-v2" xsi:schemaLocation="info:lc/xmlns/premis-v2 http://www.loc.gov/standards/premis/v2/premis.xsd" version="2.2">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:php="http://php.net/xsl"
+    xmlns:foxml="info:fedora/fedora-system:def/foxml#"
+    xmlns:audit="info:fedora/fedora-system:def/audit#"
+    xmlns:fedora="info:fedora/fedora-system:def/relations-external#"
+    xmlns:fedora-model="info:fedora/fedora-system:def/model#"
+    xmlns:islandora="http://islandora.ca/ontology/relsext#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" 
+    xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+    exclude-result-prefixes="php fedora fedora-model foxml audit islandora php rdf">
     
-    <xsl:comment>PREMIS data for Islandora object <xsl:value-of select="$pid" />. Contains object entries for each Managed datastream
+    <xsl:output method="xml" encoding="utf-8" indent="yes"/>
+    
+    <!-- Define a global parameter containing the Islandora object's PID. -->
+    <xsl:param name = "pid" select="foxml:digitalObject/@PID" />
+    
+    <!-- Global parameters exported from the XSLT processor. -->
+    <xsl:param name="premis_agent_name_organization" />
+    <xsl:param name="premis_agent_identifier_organization" />
+    <xsl:param name="premis_agent_identifier_type" />
+    <xsl:param name="premis_agent_type_organization" />
+    <!-- Note: the version number is current at time of deriving PREMIS, not at time of creation of audit log entry. -->
+    <xsl:param name="fedora_commons_version" />
+    
+    <xsl:preserve-space elements="*" />
+    
+    <xsl:template match="foxml:digitalObject">
+        <premis xmlns="info:lc/xmlns/premis-v2" xsi:schemaLocation="info:lc/xmlns/premis-v2 http://www.loc.gov/standards/premis/v2/premis.xsd" version="2.2">
+            
+            <xsl:comment>PREMIS data for Islandora object <xsl:value-of select="$pid" />. Contains object entries for each Managed datastream
     in an Islandora object, and event entries documenting all fixity checks performed on versions of those datastreams.
     Note that a datastream version that has never had a fixity check performed on it will not be linked to any fixity
     check events.</xsl:comment>
-
-
-    <!-- Objects first. --> 
-    
-    <xsl:comment>'Internal' eventIdentifierType values are comprised of Fedora datasteam ID plus ':' plus Fedora Audit Record ID.</xsl:comment>
-
-    <!-- Currently, we only describe 'managed' datastreams. -->
-    <xsl:for-each select="foxml:datastream[@CONTROL_GROUP='M']">
-        <xsl:for-each select="foxml:datastreamVersion">
-            <xsl:variable name="content_location" select="foxml:contentLocation/@REF" />
-            <xsl:variable name="datastream_id" select="@ID" />
-                <object xsi:type="file">
-                <objectIdentifier>
-                    <objectIdentifierType>Fedora Commons datastreamVersion ID</objectIdentifierType>
-                    <objectIdentifierValue><xsl:value-of select="@ID"/></objectIdentifierValue>
-                </objectIdentifier>
-                <objectCharacteristics>
-                    <!-- added test for original content (compositionLevel=0) and derived content
-                        (compositionLevel=1) -->
-                    <xsl:choose>
-                        <xsl:when test="starts-with(@ID, 'OBJ') or starts-with(@ID, 'MODS')">
-                        <compositionLevel>0</compositionLevel>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <compositionLevel>1</compositionLevel>
-                    </xsl:otherwise>
-                    </xsl:choose>
-                    <fixity>
-                    <!-- Currently not working... -->
-                    <xsl:comment>@todo: Get messageDigestAlgorithm and messageDigest working.</xsl:comment>
-                    <messageDigestAlgorithm>
-                        <xsl:value-of select="foxml:contentDigest/@TYPE" />
-                    </messageDigestAlgorithm>
-                    <messageDigest>
-                        <!-- Currently not working... -->
-                        <xsl:value-of select="foxml:contentDigest/@DIGEST" />
-                    </messageDigest>
-                    </fixity>
-                    <size><xsl:value-of select="@SIZE"/></size>
-                    <format>
-			<formatDesignation>
-                        	<formatName><xsl:value-of select="@MIMETYPE"/></formatName>
-			</formatDesignation>
-                    </format>
-                </objectCharacteristics>
-                <storage>
-                    <contentLocation>
-                        <contentLocationType>Fedora Commons contentLocation REF value</contentLocationType>
-                        <contentLocationValue><xsl:value-of select="foxml:contentLocation/@REF"/></contentLocationValue>
-                    </contentLocation>
-                </storage>
+            
+            <!-- Objects first. --> 
+            
+            <xsl:comment>'Internal' eventIdentifierType values are comprised of Fedora datasteam ID plus ':' plus Fedora Audit Record ID.</xsl:comment>
+            
+            <!-- Currently, we only describe 'managed' datastreams. -->
+            <xsl:for-each select="foxml:datastream[@CONTROL_GROUP='M']">
+                <xsl:for-each select="foxml:datastreamVersion">
+                    <xsl:variable name="content_location" select="foxml:contentLocation/@REF" />
+                    <xsl:variable name="datastream_id" select="@ID" />
+                    <object xsi:type="file">
+                        <objectIdentifier>
+                            <objectIdentifierType>Fedora Commons datastreamVersion ID</objectIdentifierType>
+                            <objectIdentifierValue><xsl:value-of select="@ID"/></objectIdentifierValue>
+                        </objectIdentifier>
+                        <objectCharacteristics>
+                            <!-- Test for original content (compositionLevel = 0) and derived content
+                        (compositionLevel = 1). -->
+                            <xsl:choose>
+                                <xsl:when test="starts-with(@ID, 'OBJ') or starts-with(@ID, 'MODS')">
+                                    <compositionLevel>0</compositionLevel>
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <compositionLevel>1</compositionLevel>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                            <fixity>
+                                <messageDigestAlgorithm>
+                                    <xsl:value-of select="foxml:contentDigest/@TYPE" />
+                                </messageDigestAlgorithm>
+                                <messageDigest>
+                                    <xsl:value-of select="foxml:contentDigest/@DIGEST" />
+                                </messageDigest>
+                            </fixity>
+                            <size><xsl:value-of select="@SIZE"/></size>
+                            <format>
+                                <formatDesignation>
+                                    <formatName><xsl:value-of select="@MIMETYPE"/></formatName>
+                                </formatDesignation>
+                            </format>
+                        </objectCharacteristics>
+                        <storage>
+                            <contentLocation>
+                                <contentLocationType>Fedora Commons contentLocation REF value</contentLocationType>
+                                <contentLocationValue><xsl:value-of select="foxml:contentLocation/@REF"/></contentLocationValue>
+                            </contentLocation>
+                        </storage>
+                        <!-- There should only be one audit:auditTrail but this for-each loop accounts for multiple. -->
+                        <xsl:for-each select="/foxml:digitalObject/foxml:datastream[@ID='AUDIT']/foxml:datastreamVersion/foxml:xmlContent/audit:auditTrail">
+                            <xsl:for-each select="audit:record">
+                                <!-- We're only interested in audit:records that document a PREMIS fixityEvent. -->
+                                <xsl:if test="contains(audit:justification, concat('PREMIS:file=', $content_location))">
+                                    <xsl:variable name="responsibility" select="audit:responsibility" />
+                                    <xsl:variable name="date" select="audit:date" />
+                                    <xsl:variable name="justification" select="audit:justification" />
+                                    <linkingEventIdentifier>
+                                        <linkingEventIdentifierType>Internal</linkingEventIdentifierType>
+                                        <linkingEventIdentifierValue><xsl:value-of select="concat($datastream_id, ':', @ID)"/></linkingEventIdentifierValue>                                                                                         
+                                    </linkingEventIdentifier>
+                                </xsl:if>
+                            </xsl:for-each>  
+                        </xsl:for-each>
+                    </object>
+                </xsl:for-each>
+            </xsl:for-each>
+            
+            <!-- Then their events. -->
+            
+            <xsl:comment>'Internal' eventIdentifierType values are comprised of Fedora datasteam ID plus ':' plus Fedora Audit Record ID.</xsl:comment>
+            
+            <xsl:for-each select="foxml:datastream[@CONTROL_GROUP='M']">
+                <xsl:for-each select="foxml:datastreamVersion">
+                    <xsl:variable name="content_location" select="foxml:contentLocation/@REF" />
+                    <xsl:variable name="datastream_id" select="@ID" />
                     <!-- There should only be one audit:auditTrail but this for-each loop accounts for multiple. -->
                     <xsl:for-each select="/foxml:digitalObject/foxml:datastream[@ID='AUDIT']/foxml:datastreamVersion/foxml:xmlContent/audit:auditTrail">
                         <xsl:for-each select="audit:record">
@@ -84,38 +113,11 @@
                                 <xsl:variable name="responsibility" select="audit:responsibility" />
                                 <xsl:variable name="date" select="audit:date" />
                                 <xsl:variable name="justification" select="audit:justification" />
-                                <linkingEventIdentifier>
-                                    <linkingEventIdentifierType>Internal</linkingEventIdentifierType>
-                                    <linkingEventIdentifierValue><xsl:value-of select="concat($datastream_id, ':', @ID)"/></linkingEventIdentifierValue>                                                                                         
-                                </linkingEventIdentifier>
-                            </xsl:if>
-                        </xsl:for-each>  
-                    </xsl:for-each>
-                    </object>
-        </xsl:for-each>
-   </xsl:for-each>
-   
-   <!-- Then their events. -->
-   
-   <xsl:comment>'Internal' eventIdentifierType values are comprised of Fedora datasteam ID plus ':' plus Fedora Audit Record ID.</xsl:comment>
-   
-    <xsl:for-each select="foxml:datastream[@CONTROL_GROUP='M']">
-        <xsl:for-each select="foxml:datastreamVersion">
-            <xsl:variable name="content_location" select="foxml:contentLocation/@REF" />
-            <xsl:variable name="datastream_id" select="@ID" />
-                <!-- There should only be one audit:auditTrail but this for-each loop accounts for multiple. -->
-                <xsl:for-each select="/foxml:digitalObject/foxml:datastream[@ID='AUDIT']/foxml:datastreamVersion/foxml:xmlContent/audit:auditTrail">
-                    <xsl:for-each select="audit:record">
-                        <!-- We're only interested in audit:records that document a PREMIS fixityEvent. -->
-                        <xsl:if test="contains(audit:justification, concat('PREMIS:file=', $content_location))">
-                            <xsl:variable name="responsibility" select="audit:responsibility" />
-                            <xsl:variable name="date" select="audit:date" />
-                            <xsl:variable name="justification" select="audit:justification" />
-                            <event>
-                                <eventIdentifier>
-                                    <eventIdentifierType>Internal</eventIdentifierType>
-                                    <eventIdentifierValue><xsl:value-of select="concat($datastream_id, ':', @ID)" /></eventIdentifierValue>
-                                </eventIdentifier>
+                                <event>
+                                    <eventIdentifier>
+                                        <eventIdentifierType>Internal</eventIdentifierType>
+                                        <eventIdentifierValue><xsl:value-of select="concat($datastream_id, ':', @ID)" /></eventIdentifierValue>
+                                    </eventIdentifier>
                                     <eventType>fixity check</eventType>
                                     <eventDateTime><xsl:value-of select="$date" /></eventDateTime>
                                     <eventOutcomeInformation>
@@ -123,25 +125,97 @@
                                             <!-- eventOutcome should be coded, not free text. -->
                                             <xsl:value-of select="substring-after(audit:justification, 'PREMIS:eventOutcome=')" />
                                         </eventOutcome>
-                                    </eventOutcomeInformation>                                                                                        
-                            </event>
-                        </xsl:if>
+                                    </eventOutcomeInformation>
+                                    <linkingAgentIdentifier>
+                                        <linkingAgentIdentifierType><xsl:value-of select="$premis_agent_identifier_type" /></linkingAgentIdentifierType>
+                                        <linkingAgentIdentifierValue><xsl:value-of select="$premis_agent_identifier_organization" /></linkingAgentIdentifierValue>
+                                        <linkingAgentRole>Implementer</linkingAgentRole>
+                                    </linkingAgentIdentifier>
+                                    <linkingAgentIdentifier>
+                                        <linkingAgentIdentifierType>URI</linkingAgentIdentifierType>
+                                        <linkingAgentIdentifierValue>http://www.fedora-commons.org/</linkingAgentIdentifierValue>
+                                        <linkingAgentRole>Validator</linkingAgentRole>
+                                    </linkingAgentIdentifier>
+                                </event>
+                            </xsl:if>
+                        </xsl:for-each>
                     </xsl:for-each>
-                </xsl:for-each>
-       </xsl:for-each>  
-    </xsl:for-each>
-
-    <!-- Then agents. --> 
-    <agent>
-        <agentIdentifier>
-            <agentIdentifierType><xsl:value-of select="$premis_agent_identifier_type" /></agentIdentifierType>
-            <agentIdentifierValue><xsl:value-of select="$premis_agent_identifier_organization" /></agentIdentifierValue>
-        </agentIdentifier>
-        <agentName><xsl:value-of select="$premis_agent_name_organization" /></agentName>
-        <agentType><xsl:value-of select="$premis_agent_type_organization" /></agentType>
-    </agent>
-   
-   </premis>
-</xsl:template>
-
+                </xsl:for-each>  
+            </xsl:for-each>
+            
+            <!-- Then agents. --> 
+            <agent>
+                <agentIdentifier>
+                    <agentIdentifierType><xsl:value-of select="$premis_agent_identifier_type" /></agentIdentifierType>
+                    <agentIdentifierValue><xsl:value-of select="$premis_agent_identifier_organization" /></agentIdentifierValue>
+                </agentIdentifier>
+                <agentName><xsl:value-of select="$premis_agent_name_organization" /></agentName>
+                <agentType><xsl:value-of select="$premis_agent_type_organization" /></agentType>
+            </agent>
+            <agent>
+                <agentIdentifier>
+                    <agentIdentifierType>URI</agentIdentifierType>
+                    <agentIdentifierValue>http://www.fedora-commons.org/</agentIdentifierValue>
+                </agentIdentifier>
+                <agentName>Fedora Repository <xsl:value-of select="$fedora_commons_version" /></agentName>
+                <agentType>software</agentType>
+            </agent>
+            <!-- rights metadata -->
+            <rights>
+                <rightsStatement>
+                    <rightsStatementIdentifier>
+                        <rightsStatementIdentifierType>Fedora PID</rightsStatementIdentifierType>
+                        <rightsStatementIdentifierValue><xsl:value-of select="$pid"
+                        />-rights</rightsStatementIdentifierValue>
+                    </rightsStatementIdentifier>
+                    <rightsBasis>
+                        <!-- values are copyright, license, statue, other -->
+                        <xsl:choose>
+                            <xsl:when
+                                test="contains(/foxml:digitalObject/foxml:datastream/foxml:datastreamVersion/foxml:xmlContent/oai_dc:dc/dc:rights,'copyright')
+                                or
+                                contains(/foxml:digitalObject/foxml:datastream/foxml:datastreamVersion/foxml:xmlContent/oai_dc:dc/dc:rights,'public domain')
+                                ">copyright</xsl:when>
+                            <xsl:when
+                                test="contains(/foxml:digitalObject/foxml:datastream/foxml:datastreamVersion/foxml:xmlContent/oai_dc:dc/dc:rights,'creative commons')"
+                                >license</xsl:when>
+                            <xsl:otherwise>other</xsl:otherwise>
+                        </xsl:choose>
+                    </rightsBasis>
+                    <xsl:choose>
+                        <xsl:when
+                            test="/foxml:digitalObject/foxml:datastream/foxml:datastreamVersion/foxml:xmlContent/oai_dc:dc/dc:rights[contains(.,'copyright')
+                            or contains(.,'public domain')]">
+                            <copyrightInformation>
+                                <copyrightStatus><!-- values include copyrighted, publicdomain, unknown -->
+                                    <xsl:choose>
+                                        <xsl:when
+                                            test="/foxml:digitalObject/foxml:datastream/foxml:datastreamVersion/foxml:xmlContent/oai_dc:dc/dc:rights[contains(.,'copyright')]"
+                                            >copyrighted</xsl:when>
+                                        <xsl:when
+                                            test="/foxml:digitalObject/foxml:datastream/foxml:datastreamVersion/foxml:xmlContent/oai_dc:dc/dc:rights[contains(.,'public domain')]">public domain</xsl:when>
+                                        <xsl:otherwise>unknown</xsl:otherwise>
+                                    </xsl:choose>
+                                </copyrightStatus>
+                                <copyrightJurisdiction>ca</copyrightJurisdiction>
+                            </copyrightInformation>
+                        </xsl:when>
+                        <xsl:when
+                            test="/foxml:digitalObject/foxml:datastream/foxml:datastreamVersion/foxml:xmlContent/oai_dc:dc/dc:rights[contains(.,'creative commons')]">
+                            <licenseInformation>
+                                <licenseTerms><xsl:value-of select="/foxml:digitalObject/foxml:datastream/foxml:datastreamVersion/foxml:xmlContent/oai_dc:dc/dc:rights"/></licenseTerms>
+                            </licenseInformation>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <statuteInformation>
+                                <statuteJurisdiction>ca</statuteJurisdiction>
+                                <statuteCitation><!-- An identifying designation for the statute.  --></statuteCitation>
+                            </statuteInformation>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </rightsStatement>
+            </rights>
+        </premis>
+    </xsl:template>
+    
 </xsl:stylesheet>

--- a/xml/foxml_to_premis.xsl
+++ b/xml/foxml_to_premis.xsl
@@ -19,9 +19,13 @@
     <xsl:param name="premis_agent_identifier_organization" />
     <xsl:param name="premis_agent_identifier_type" />
     <xsl:param name="premis_agent_type_organization" />
+    <!-- parameters for rights -->
+    <xsl:param name="premis_rights_statuteInformation_statuteJurisdiction"/>
+    <xsl:param name="premis_rights_copyrightInformation_copyrightStatus_copyrightJurisdiction"/>
+    
     <!-- Note: the version number is current at time of deriving PREMIS, not at time of creation of audit log entry. -->
     <xsl:param name="fedora_commons_version" />
-    
+
     <xsl:preserve-space elements="*" />
     
     <xsl:template match="foxml:digitalObject">
@@ -172,44 +176,46 @@
                         <!-- values are copyright, license, statue, other -->
                         <xsl:choose>
                             <xsl:when
-                                test="contains(/foxml:digitalObject/foxml:datastream/foxml:datastreamVersion/foxml:xmlContent/oai_dc:dc/dc:rights,'copyright')
+                                test="contains(/foxml:digitalObject/foxml:datastream/foxml:datastreamVersion[last()]/foxml:xmlContent/oai_dc:dc/dc:rights,'copyright')
                                 or
-                                contains(/foxml:digitalObject/foxml:datastream/foxml:datastreamVersion/foxml:xmlContent/oai_dc:dc/dc:rights,'public domain')
-                                ">copyright</xsl:when>
+                                contains(/foxml:digitalObject/foxml:datastream/foxml:datastreamVersion[last()]/foxml:xmlContent/oai_dc:dc/dc:rights,'public domain')">copyright</xsl:when>
                             <xsl:when
-                                test="contains(/foxml:digitalObject/foxml:datastream/foxml:datastreamVersion/foxml:xmlContent/oai_dc:dc/dc:rights,'creative commons')"
+                                test="contains(/foxml:digitalObject/foxml:datastream/foxml:datastreamVersion[last()]/foxml:xmlContent/oai_dc:dc/dc:rights,'creative commons')"
                                 >license</xsl:when>
                             <xsl:otherwise>other</xsl:otherwise>
                         </xsl:choose>
                     </rightsBasis>
                     <xsl:choose>
                         <xsl:when
-                            test="/foxml:digitalObject/foxml:datastream/foxml:datastreamVersion/foxml:xmlContent/oai_dc:dc/dc:rights[contains(.,'copyright')
-                            or contains(.,'public domain')]">
+                            test="contains(/foxml:digitalObject/foxml:datastream/foxml:datastreamVersion[last()]/foxml:xmlContent/oai_dc:dc/dc:rights,'copyright')
+                            or contains(/foxml:digitalObject/foxml:datastream/foxml:datastreamVersion[last()]/foxml:xmlContent/oai_dc:dc/dc:rights,'public domain')">
                             <copyrightInformation>
                                 <copyrightStatus><!-- values include copyrighted, publicdomain, unknown -->
                                     <xsl:choose>
                                         <xsl:when
-                                            test="/foxml:digitalObject/foxml:datastream/foxml:datastreamVersion/foxml:xmlContent/oai_dc:dc/dc:rights[contains(.,'copyright')]"
+                                            test="contains(/foxml:digitalObject/foxml:datastream/foxml:datastreamVersion[last()]/foxml:xmlContent/oai_dc:dc/dc:rights,'copyright')"
                                             >copyrighted</xsl:when>
                                         <xsl:when
-                                            test="/foxml:digitalObject/foxml:datastream/foxml:datastreamVersion/foxml:xmlContent/oai_dc:dc/dc:rights[contains(.,'public domain')]">public domain</xsl:when>
+                                            test="contains(/foxml:digitalObject/foxml:datastream/foxml:datastreamVersion[last()]/foxml:xmlContent/oai_dc:dc/dc:rights,'public domain')">public domain</xsl:when>
                                         <xsl:otherwise>unknown</xsl:otherwise>
                                     </xsl:choose>
                                 </copyrightStatus>
-                                <copyrightJurisdiction>ca</copyrightJurisdiction>
+                                <copyrightJurisdiction><xsl:value-of select="$premis_rights_copyrightInformation_copyrightStatus_copyrightJurisdiction" /></copyrightJurisdiction>
+                                <copyrightNote><xsl:value-of
+                                    select="/foxml:digitalObject/foxml:datastream/foxml:datastreamVersion[last()]/foxml:xmlContent/oai_dc:dc/dc:rights"/></copyrightNote>
                             </copyrightInformation>
                         </xsl:when>
                         <xsl:when
-                            test="/foxml:digitalObject/foxml:datastream/foxml:datastreamVersion/foxml:xmlContent/oai_dc:dc/dc:rights[contains(.,'creative commons')]">
+                            test="contains(/foxml:digitalObject/foxml:datastream/foxml:datastreamVersion[last()]/foxml:xmlContent/oai_dc:dc/dc:rights,'creative commons')">
                             <licenseInformation>
-                                <licenseTerms><xsl:value-of select="/foxml:digitalObject/foxml:datastream/foxml:datastreamVersion/foxml:xmlContent/oai_dc:dc/dc:rights"/></licenseTerms>
+                                <licenseTerms><xsl:value-of select="/foxml:digitalObject/foxml:datastream/foxml:datastreamVersion[last()]/foxml:xmlContent/oai_dc:dc/dc:rights"/></licenseTerms>
                             </licenseInformation>
                         </xsl:when>
                         <xsl:otherwise>
                             <statuteInformation>
-                                <statuteJurisdiction>ca</statuteJurisdiction>
+                                <statuteJurisdiction><xsl:value-of select="$premis_rights_statuteInformation_statuteJurisdiction" /></statuteJurisdiction>
                                 <statuteCitation><!-- An identifying designation for the statute.  --></statuteCitation>
+                                <statuteNote><xsl:value-of select="/foxml:digitalObject/foxml:datastream/foxml:datastreamVersion[last()]/foxml:xmlContent/oai_dc:dc/dc:rights"/></statuteNote>
                             </statuteInformation>
                         </xsl:otherwise>
                     </xsl:choose>

--- a/xml/premis_to_html.xsl
+++ b/xml/premis_to_html.xsl
@@ -3,6 +3,8 @@
 	xmlns:premis="info:lc/xmlns/premis-v2" 
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" exclude-result-prefixes="xsi premis">
 	
+	
+	
 	<xsl:output method="xml" omit-xml-declaration="yes" encoding="UTF-8" indent="yes"/>
 	<xsl:strip-space elements="*" />
 	
@@ -89,6 +91,34 @@
 				</table>
 			</div>
 		</fieldset>
+	
+	<!-- PREMIS RIGHTS CONTAINER -->
+	<fieldset class="form-wrapper">
+		<legend>
+			<span class="fieldset-legend">PREMIS Rights</span>
+		</legend>
+		<div class="fieldset-wrapper">
+			<table class="sticky-header" style="position: fixed; top: 65px; left: 152.5px; visibility: hidden; width: 600px;">
+				<thead style="display: block;">
+					<tr>
+						<th style="width: 279px; display: table-cell;">Field</th>
+						<th style="width: 279px; display: table-cell;">Value</th>
+					</tr>
+				</thead>
+			</table>
+			<table class="islandora_premis_table sticky-enabled tableheader-processed sticky-table">
+				<thead>
+					<tr>
+						<th>Field</th>
+						<th>Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					<xsl:apply-templates select="premis:rights"/>
+				</tbody>
+			</table>
+		</div>
+	</fieldset>
 	</xsl:template>
 	
 	<xsl:template match="premis:object[@xsi:type='file']">		
@@ -188,4 +218,23 @@
 		</tr>
 	</xsl:template>
 	
+	
+	<xsl:template match="premis:rights">
+		<tr class="odd">
+			<td class="islandora_premis_table_labels"><xsl:value-of
+				select="name(premis:rightsStatement/premis:rightsStatementIdentifier/premis:rightsStatementIdentifierType)"/></td>
+			<td class="islandora_premis_table_values"><xsl:value-of select="premis:rightsStatement/premis:rightsStatementIdentifier/premis:rightsStatementIdentifierType"/></td>
+		</tr>
+		<tr class="even">
+			<td class="islandora_premis_table_labels"><xsl:value-of select="name(premis:rightsStatement/premis:rightsStatementIdentifier/premis:rightsStatementIdentifierValue)"/></td>
+			<td class="islandora_premis_table_values"><xsl:value-of select="premis:rightsStatement/premis:rightsStatementIdentifier/premis:rightsStatementIdentifierValue"/></td>
+		</tr>
+		<tr class="odd">
+			<td class="islandora_premis_table_labels"><xsl:value-of
+				select="name(premis:rightsStatement/premis:rightsBasis)"/></td>
+			<td class="islandora_premis_table_values"><xsl:value-of select="premis:rightsStatement/premis:rightsBasis"/></td>
+		</tr>
+<!-- to do: flesh out rights -->
+
+	</xsl:template>
 </xsl:stylesheet>

--- a/xml/premis_to_html.xsl
+++ b/xml/premis_to_html.xsl
@@ -235,6 +235,46 @@
 			<td class="islandora_premis_table_values"><xsl:value-of select="premis:rightsStatement/premis:rightsBasis"/></td>
 		</tr>
 <!-- to do: flesh out rights -->
-
+		<xsl:choose>
+			<xsl:when test="premis:rightsStatement/premis:rightsBasis = 'copyright'">
+				<tr class="even">
+					<td class="islandora_premis_table_labels"><xsl:value-of
+						select="name(premis:rightsStatement/premis:copyrightInformation/premis:copyrightStatus)"/></td>
+					<td class="islandora_premis_table_values"><xsl:value-of select="premis:rightsStatement/premis:copyrightInformation/premis:copyrightStatus"/></td>
+				</tr>
+				<tr class="odd">
+					<td class="islandora_premis_table_labels"><xsl:value-of
+						select="name(premis:rightsStatement/premis:copyrightInformation/premis:copyrightJurisdiction)"/></td>
+					<td class="islandora_premis_table_values"><xsl:value-of select="premis:rightsStatement/premis:copyrightInformation/premis:copyrightJurisdiction"/></td>
+				</tr>
+				<tr class="even">
+					<td class="islandora_premis_table_labels"><xsl:value-of
+						select="name(premis:rightsStatement/premis:copyrightInformation/premis:copyrightNote)"/></td>
+					<td class="islandora_premis_table_values"><xsl:value-of
+						select="premis:rightsStatement/premis:copyrightInformation/premis:copyrightNote"/></td>
+				</tr>
+			</xsl:when>
+			<xsl:when test="premis:rightsStatement/premis:rightsBasis = 'license'">
+				<tr class="even">
+					<td class="islandora_premis_table_labels"><xsl:value-of select="name(premis:rightsStatement/premis:licenseInformation/premis:licenseTerms)"/></td>
+					<td class="islandora_premis_table_values"><xsl:value-of select="premis:rightsStatement/premis:licenseInformation/premis:licenseTerms"/></td>
+				</tr>
+			</xsl:when>
+			<xsl:otherwise>
+				<tr class="even">
+					<td class="islandora_premis_table_labels"><xsl:value-of select="name(premis:rightsStatement/premis:statuteInformation/premis:statuteJurisdiction)"/></td>
+					<td class="islandora_premis_table_values"><xsl:value-of select="premis:rightsStatement/premis:statuteInformation/premis:statuteJurisdiction"/></td>
+				</tr>
+				<tr class="odd">
+					<td class="islandora_premis_table_labels"><xsl:value-of select="name(premis:rightsStatement/premis:statuteInformation/premis:statuteCitation)"/></td>
+					<td class="islandora_premis_table_values"><xsl:value-of	select="premis:rightsStatement/premis:statuteInformation/premis:statuteCitation"/></td>
+				</tr>
+				<tr class="even">
+					<td class="islandora_premis_table_labels"><xsl:value-of	select="name(premis:rightsStatement/premis:statuteInformation/premis:statuteNote)"/></td>
+					<td class="islandora_premis_table_values"><xsl:value-of select="premis:rightsStatement/premis:statuteInformation/premis:statuteNote"/></td>
+				</tr>
+			</xsl:otherwise>
+		</xsl:choose>
+		
 	</xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
pulls dc:rights from last version of DC datastream. fleshed out the premis to html to include additional details.
