### PR TITLE
Added 'view premis metadata' permission

### DIFF
--- a/islandora_premis.module
+++ b/islandora_premis.module
@@ -50,6 +50,10 @@ function islandora_premis_permission() {
       'title' => t('Download PREMIS metadata'),
       'description' => t('Download PREMIS metadata'),
     ),
+    'view premis metadata' => array(
+      'title' => t('View PREMIS metadata'),
+      'description' => t('View PREMIS metadata'),
+    ),
   );
 }
 


### PR DESCRIPTION
islandora_premis_view checks for this permission in order to display markup, but the module is missing this permission definition
