### PR TITLE
ISLANDORA-1722 don't show PREMIS tab unless you have PREMIS permissions.

### DIFF
--- a/islandora_premis.module
+++ b/islandora_premis.module
@@ -88,6 +88,9 @@ function islandora_premis_xml_download($output) {
  *   otherwise.
  */
 function islandora_premis_access_callback($object) {
+  if (!user_access('view premis metadata') && !user_access('download premis metadata')) {
+    return FALSE;
+  }
   return is_object($object) && isset($object['DC']) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object['DC'])
     && !isset($object['COLLECTION_POLICY']);
 }

--- a/islandora_premis.module
+++ b/islandora_premis.module
@@ -88,9 +88,6 @@ function islandora_premis_xml_download($output) {
  *   otherwise.
  */
 function islandora_premis_access_callback($object) {
-  if (!user_access('view premis metadata') && !user_access('download premis metadata')) {
-    return FALSE;
-  }
   return is_object($object) && isset($object['DC']) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object['DC'])
-    && !isset($object['COLLECTION_POLICY']);
+    && !isset($object['COLLECTION_POLICY']) && (user_access('view premis metadata') || user_access('download premis metadata'));
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1722
# What does this Pull Request do?

Checks for PREMIS permissions before displaying the PREMIS tab.
# What's new?

Added a Drupal permission check to not show the PREMIS tab unless you can either "view" or "download" premis metadata. 
# How should this be tested?

Log in as a user without permission to view or download PREMIS metadata. Current behaviour is to display the PREMIS tab which is a blank tab. New behaviour is to not display the PREMIS tab.

If a user has permission to view, download, or both, the behaviour should remain the same (PREMIS tab is visible and displays PREMIS table and/or download link).
# Additional Notes:

Release PR: https://github.com/Islandora/islandora_premis/pull/55
# Interested parties

@dmoses and @jordandukart (@jordandukart++ for pointing us directly to the code in error.) 
