### PR TITLE
7.x islandora 1830

### DIFF
--- a/xml/foxml_to_premis.xsl
+++ b/xml/foxml_to_premis.xsl
@@ -34,6 +34,8 @@
       <xsl:comment>Some things to note:</xsl:comment>
       <xsl:comment>'Internal' eventIdentifierType values in this PREMIS document are comprised of Fedora
         datasteam ID plus ':' plus Fedora Audit Record ID.</xsl:comment>
+      <xsl:comment>This PREMIS document does not contain any linkingEventIdentifier elements. eventIdentifierValue
+        values can be linked to objects using the naming convention described in the previous comment.</xsl:comment>
       <xsl:comment>Datastreams in the Inline XML control group (X) (e.g., DC and RELS-EXT) do not have a contentLocation
         element in the FOXML, so they do not have a corresponding contentLocationValue element in PREMIS.</xsl:comment>
       <xsl:comment>The eventOutcome element is "coded" (as recommended in the PREMIS Data Dictionary) by the
@@ -88,25 +90,6 @@
                 </contentLocationValue>
               </contentLocation>
             </storage>
-            <!-- There should only be one audit:auditTrail but this for-each loop accounts for multiple. -->
-            <xsl:for-each select="/foxml:digitalObject/foxml:datastream[@ID='AUDIT']/foxml:datastreamVersion/foxml:xmlContent/audit:auditTrail">
-              <xsl:variable name="datastream_version_id" select="foxml:datastreamVersion/@ID"/>
-              <xsl:variable name="event_content_location" select="concat($pid, '+', $datastream_id, '+', $datastream_version_id)"/>
-              <xsl:for-each select="audit:record">
-                <!-- We're only interested in audit:records that document a PREMIS fixityEvent. -->
-                <xsl:variable name="justification" select="audit:justification"/>
-                <xsl:if test="contains($justification, concat('PREMIS:file=', foxml:contentLocation/@REF))">
-                  <xsl:variable name="responsibility" select="audit:responsibility"/>
-                  <xsl:variable name="date" select="audit:date"/>
-                  <linkingEventIdentifier>
-                    <linkingEventIdentifierType>Internal</linkingEventIdentifierType>
-                    <linkingEventIdentifierValue>
-                      <xsl:value-of select="concat($datastream_id, ':', @ID)"/>
-                    </linkingEventIdentifierValue>
-                  </linkingEventIdentifier>
-                </xsl:if>
-              </xsl:for-each>
-            </xsl:for-each>
           </object>
         </xsl:for-each>
       </xsl:for-each>


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1830

# What does this Pull Request do?

Removes superfluous `<linkingEventIdentifier>` elements from the PREMIS XML.


# What's new?

This PR changes the `foxml_to_premis.xsl` stylesheet so that it does not generate `<linkingEventIdentifier>` entries, which, as explained in the JIRA ticket are optionl in PREMIS and in our case unnecessary. It also adds the following comment to the output of the stylesheet:

```xml
<!--This PREMIS document does not contain any linkingEventIdentifier elements. eventIdentifierValue
>         values can be linked to objects using the naming convention described in the previous comment.-->
```

# How should this be tested?

1. In the 7.x branch, download a PREMIS file for an object (e.g., `islandora/object/islandora:102/manage/premis`, then click the "Download" link)
1. Switch to the 7.x-ISLANDORA-1830 branch and download the PREMIS file for the same object.
1. Diff the two files. The one generated in 7.x should have a lot of `<linkingEventIdentifier>` entries (each with `<linkingEventIdentifierType>` and `<linkingEventIdentifierValue>` children) that are missing from the PREMIS file generated in 7.x-ISLANDORA-1830.
1. The missing `<linkingEventIdentifier>` entries should be the only difference other than the new comment at the top of the file.


# Interested parties
@bradspry, @ruebot, @dmoses, @Islandora/7-x-1-x-committers
