### PR TITLE
Work on ISLANDORA-2016.

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -62,6 +62,9 @@ function islandora_premis_transform_foxml_to_premis(AbstractObject $object) {
     drupal_not_found();
   }
 
+  // See https://jira.duraspace.org/browse/ISLANDORA-2016.
+  $creating_application_info = system_get_info('module', 'islandora');
+
   return islandora_premis_run_xsl_transform(array(
     'input' => $foxml_str,
     'xsl' => drupal_get_path('module', 'islandora_premis') . '/xml/foxml_to_premis.xsl',
@@ -74,6 +77,7 @@ function islandora_premis_transform_foxml_to_premis(AbstractObject $object) {
         'premis_agent_identifier_organization' => variable_get('islandora_premis_agent_identifier', 'some_unique_string'),
         'premis_agent_identifier_type' => variable_get('islandora_premis_agent_identifier_type', 'MARC Organization Codes'),
         'premis_agent_type_organization' => variable_get('islandora_premis_agent_type', 'organization'),
+        'premis_object_creating_application_name' => $creating_application_info['name'],
         'fedora_commons_version' => islandora_premis_get_fc_version(),
       ),
     ),

--- a/xml/foxml_to_premis.xsl
+++ b/xml/foxml_to_premis.xsl
@@ -21,6 +21,7 @@
   <xsl:param name="premis_agent_identifier_organization"/>
   <xsl:param name="premis_agent_identifier_type"/>
   <xsl:param name="premis_agent_type_organization"/>
+  <xsl:param name="premis_object_creating_application_name"/>
   <!-- Note: the version number is current at time of deriving PREMIS, not at time of creation of audit log entry. -->
   <xsl:param name="fedora_commons_version"/>
   <xsl:preserve-space elements="*"/>
@@ -38,6 +39,9 @@
         values can be linked to objects using the naming convention described in the previous comment.</xsl:comment>
       <xsl:comment>Datastreams in the Inline XML control group (X) (e.g., DC and RELS-EXT) do not have a contentLocation
         element in the FOXML, so they do not have a corresponding contentLocationValue element in PREMIS.</xsl:comment>
+      <xsl:comment>creatingApplicationName will be 'Islandora'. See https://jira.duraspace.org/browse/ISLANDORA-2016 for
+        more info. dateCreatedByApplication uses the Fedora datastream version CREATED value. These properties
+        are applied to all datastreams, even OBJ, and all datastream versions.</xsl:comment>
       <xsl:comment>The eventOutcome element is "coded" (as recommended in the PREMIS Data Dictionary) by the
         Islandora Checksum Checker module in this PREMIS document as follows: "[checksum type] checksum validated.",
         "Invalid [checksum type] detected.", or "Checksums not enabled."</xsl:comment>
@@ -54,6 +58,14 @@
             </objectIdentifier>
             <objectCharacteristics>
               <compositionLevel>0</compositionLevel>
+              <creatingApplication>
+                <creatingApplicationName>
+                  <xsl:value-of select="$premis_object_creating_application_name"/>
+                </creatingApplicationName>
+                <dateCreatedByApplication> 
+                  <xsl:value-of select="@CREATED"/>
+                </dateCreatedByApplication> 
+              </creatingApplication>
               <fixity>
                 <messageDigestAlgorithm>
                   <xsl:value-of select="foxml:contentDigest/@TYPE"/>

--- a/xml/premis_to_html.xsl
+++ b/xml/premis_to_html.xsl
@@ -139,6 +139,22 @@
     </tr>
     <tr class="even">
       <td class="islandora_premis_table_labels">
+        <xsl:value-of select="name(premis:objectCharacteristics/premis:creatingApplication/premis:creatingApplicationName)"/>
+      </td>
+      <td class="islandora_premis_table_values">
+        <xsl:value-of select="premis:objectCharacteristics/premis:creatingApplication/premis:creatingApplicationName"/>
+      </td>
+    </tr>
+    <tr class="odd">
+      <td class="islandora_premis_table_labels">
+        <xsl:value-of select="name(premis:objectCharacteristics/premis:creatingApplication/premis:dateCreatedByApplication)"/>
+      </td>
+      <td class="islandora_premis_table_values">
+        <xsl:value-of select="premis:objectCharacteristics/premis:creatingApplication/premis:dateCreatedByApplication"/>
+      </td>
+    </tr>
+    <tr class="even">
+      <td class="islandora_premis_table_labels">
         <xsl:value-of select="name(premis:objectCharacteristics/premis:fixity/premis:messageDigestAlgorithm)"/>
       </td>
       <td class="islandora_premis_table_values">


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2016

# What does this Pull Request do?

Adds `<creatingApplicationName>` and `<dateCreatedByApplication>` elements for each datastream version to the PREMIS XML.

# What's new?

* Derives `<creatingApplicationName>` from the name of the 'islandora' module (i.e., 'Islandora').
* Derives `<dateCreatedByApplication>` from FOXML's `datastreamVersion/CREATED` attribute value.
* Adds both of these new elements to the appropriate place in each datastream version's object properties in the PREMIS XML.
* When the HTML version of the PREMIS is viewed, for each datastream version, adds a new row for each of these properties as illustrated in the attached screencap.

# How should this be tested?

* On an instance with Islandora PREMIS enabled, check out the mjordan/ISLANDORA-2016 branch.
* As a user with View and Download PREMIS permissions, visit an object's Manage tab, then click on the PREMIS subtab.
  * Look for the "creatingApplicationName" and "dateCreatedByApplication" rows in the table. They should be there :8^)
* Download the PREMIS XML by clicking on the "Download PREMIS" link.
  * Open the XML file in an editor. You should see the following markup for each datastream version (date will differ):
```xml
   <creatingApplicationName>Islandora</creatingApplicationName>
    <dateCreatedByApplication>2017-08-23T17:23:43.421Z</dateCreatedByApplication>
```

# Additional Notes:

Documentation at https://wiki.duraspace.org/display/ISLANDORA/Islandora+PREMIS should be updated to indicate that the creating application and date of creation will now be applied to each datastream version.

# Interested parties

@Islandora/7-x-1-x-committers

![islandora_2016_html](https://user-images.githubusercontent.com/403918/29637195-3fd04900-8808-11e7-95e1-e94173a9b888.png)

