### PR TITLE
Context for access checks.

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -112,10 +112,10 @@ function islandora_premis_transform_premis_to_html(AbstractObject $object) {
  */
 function islandora_premis_view(AbstractObject $object) {
   $tab = array();
-  if (user_access('download premis metadata')) {
+  if (islandora_object_access('download premis metadata', $object)) {
     $tab['link'] = array('#markup' => l(t('Download PREMIS'), "islandora/object/{$object->id}/manage/premis/download"));
   }
-  if (user_access('view premis metadata')) {
+  if (islandora_object_access('view premis metadata', $object)) {
     $tab['premis'] = array('#markup' => islandora_premis_transform_premis_to_html($object));
   }
   return $tab;

--- a/islandora_premis.module
+++ b/islandora_premis.module
@@ -25,8 +25,8 @@ function islandora_premis_menu() {
       'page callback' => 'islandora_premis_transform_foxml_to_premis',
       'page arguments' => array(2),
       'access callback' => 'islandora_premis_access_callback',
-      'access arguments' => array(2),
-      'delivery callback' => 'islandora_premis_xml_download',
+      'access arguments' => array(2, TRUE),
+      'delivery callback' => '_islandora_premis_xml_download',
       'file' => 'includes/utilities.inc',
     ),
     'admin/islandora/tools/premis' => array(
@@ -60,17 +60,32 @@ function islandora_premis_permission() {
 /**
  * Delivery callback used to download the output as XML.
  *
+ * Wraps a "download premis metadata" access check around, for the case of any
+ * legacy uses.
+ *
+ * @see _islandora_premis_xml_download()
+ *
  * @param string $output
  *   The content to download.
  */
 function islandora_premis_xml_download($output) {
   if (user_access('download premis metadata')) {
-    drupal_add_http_header('Content-type', 'text/xml;charset=utf8');
-    drupal_add_http_header('Content-length', strlen($output));
-    drupal_add_http_header('Content-Disposition', 'attachment; filename="premis.xml"');
-    print $output;
-    drupal_page_footer();
+    return _islandora_premis_xml_download($output);
   }
+}
+
+/**
+ * Delivery callback used to download the output as XML.
+ *
+ * @param string $output
+ *   The content to download.
+ */
+function _islandora_premis_xml_download($output) {
+  drupal_add_http_header('Content-type', 'text/xml;charset=utf8');
+  drupal_add_http_header('Content-length', strlen($output));
+  drupal_add_http_header('Content-Disposition', 'attachment; filename="premis.xml"');
+  print $output;
+  drupal_page_footer();
 }
 
 /**
@@ -82,12 +97,15 @@ function islandora_premis_xml_download($output) {
  * @param AbstractObject $object
  *   The object to test, if NULL the given object doesn't exist or is
  *   inaccessible.
+ * @param bool $download
+ *   A boolean flag. TRUE if we're checking for a download; FALSE for viewing.
  *
  * @return bool
  *   TRUE if the user is allowed to access the premis interface, FALSE
  *   otherwise.
  */
-function islandora_premis_access_callback($object) {
+function islandora_premis_access_callback($object, $download = FALSE) {
   return is_object($object) && isset($object['DC']) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object['DC'])
-    && !isset($object['COLLECTION_POLICY']) && (user_access('view premis metadata') || user_access('download premis metadata'));
+    && !isset($object['COLLECTION_POLICY']) && islandora_object_access($download ? 'download premis metadata' : 'view premis metadata', $object);
+
 }


### PR DESCRIPTION
**JIRA Ticket**: [ISLANDORA-2064](https://jira.duraspace.org/browse/ISLANDORA-2064)

# What does this Pull Request do?

Add more context to access check, permitting overrides. Also, slight adjustment to the download delivery callback so that the applicable access check happens earlier. 

# What's new?

* Use `islandora_object_access()` instead of `user_access()` for access control to allow things to be influenced from our access hooks.

# How should this be tested?

Primarily, regression testing: Things should work as they did.

Simple test module exposing a block allowing the permissions to be denied via our hooks: https://github.com/adam-vessey/islandora_2064_test

# Additional Notes:

* **Does this change require documentation to be updated?** No.
* **Does this change add any new dependencies?** No.
* **Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?** No.
* **Could this change impact execution of existing code?** Unlikely, but it _is_ possible.

# Interested parties

@mjordan (as component manager), @DiegoPino (since this is bubbling out of other PRs), @Islandora/7-x-1-x-committers

---

The search:
```
islandora_premis @ 4716474ff7d980f7bdcd0c8956bc983dcfc125f9
/var/www/drupal7/sites/all/modules/islandora_premis$ git grep -n user_access
# Fixed...
includes/utilities.inc:115:  if (user_access('download premis metadata')) {
# Fixed...
includes/utilities.inc:118:  if (user_access('view premis metadata')) {
# Tricky, oddly structured logic due to share access check below... fixing logic below
# can allow this check to go away...
islandora_premis.module:67:  if (user_access('download premis metadata')) {
# Introduced a flag to check only one of the permissions as necessary.
islandora_premis.module:92:    && !isset($object['COLLECTION_POLICY']) && (user_access('view premis metadata') || user_access('download premis metadata'));
```