### PR TITLE
ISLANDORA-2096 fix download menu permssion.

### DIFF
--- a/islandora_premis.module
+++ b/islandora_premis.module
@@ -90,7 +90,7 @@ function _islandora_premis_xml_download($output) {
     drupal_page_footer();
   }
   else {
-    watchdog('access denied', check_plain($_GET['q']), NULL, WATCHDOG_WARNING);
+    watchdog('access denied', '!q', array('!q' => check_plain($_GET['q'])), WATCHDOG_WARNING);
     drupal_add_http_header('Status', '403 Forbidden');
   }
 }

--- a/islandora_premis.module
+++ b/islandora_premis.module
@@ -81,8 +81,7 @@ function islandora_premis_xml_download($output) {
  *   The content to download.
  */
 function _islandora_premis_xml_download($output) {
-  $pid = arg(2);
-  $object = islandora_object_load($pid);
+  $object = menu_get_object('islandora_object', 2);
   if (islandora_object_access('download premis metadata', $object)) {
     drupal_add_http_header('Content-type', 'text/xml;charset=utf8');
     drupal_add_http_header('Content-length', strlen($output));

--- a/islandora_premis.module
+++ b/islandora_premis.module
@@ -81,11 +81,19 @@ function islandora_premis_xml_download($output) {
  *   The content to download.
  */
 function _islandora_premis_xml_download($output) {
-  drupal_add_http_header('Content-type', 'text/xml;charset=utf8');
-  drupal_add_http_header('Content-length', strlen($output));
-  drupal_add_http_header('Content-Disposition', 'attachment; filename="premis.xml"');
-  print $output;
-  drupal_page_footer();
+  $pid = arg(2);
+  $object = islandora_object_load($pid);
+  if (islandora_object_access('download premis metadata', $object)) {
+    drupal_add_http_header('Content-type', 'text/xml;charset=utf8');
+    drupal_add_http_header('Content-length', strlen($output));
+    drupal_add_http_header('Content-Disposition', 'attachment; filename="premis.xml"');
+    print $output;
+    drupal_page_footer();
+  }
+  else {
+    watchdog('access denied', check_plain($_GET['q']), NULL, WATCHDOG_WARNING);
+    drupal_add_http_header('Status', '403 Forbidden');
+  }
 }
 
 /**


### PR DESCRIPTION
**JIRA Ticket**: (link)

https://github.com/Islandora/islandora_premis/pull/70

# What does this Pull Request do?

Enforces the `download premis metadata` permission.

# What's new?

Added an `if (islandora_object_access('download premis metadata', $object))` check to the delivery callback for the PREMIS XML file, and appropriate HTTP status code to cover cases where user does not have this permission.

# How should this be tested?

In the 7.x branch,

1. As a user who does not have the 'download premis metadata' permission, visit the URL for downloading a PREMIS XML file, e.g. `http://localhost:8000/islandora/object/test:1/manage/premis/download`. The file will download.
1. Check out the 7.x-ISLANDORA-2096 branch and clear your menu cache, for good measure.
1. As the same user, try to download the PREMIS file. You should get a 403 Unauthorized response.

# Interested parties

@adam-vessey @rosiel @DiegoPino 
